### PR TITLE
Fix "'findstr' is not recognized as ..."

### DIFF
--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -1,3 +1,4 @@
+@echo off
 :: This batch file handles managing an Erlang node as a Windows service.
 ::
 :: Commands provided:
@@ -19,6 +20,9 @@
 @set rel_vsn={{ rel_vsn }}
 @set erts_vsn={{ erts_vsn }}
 @set erl_opts={{ erl_opts }}
+
+:: Make sure `findstr` is accessible
+@set PATH=%PATH%;%SystemRoot%\System32
 
 :: Discover the release root directory from the directory
 :: of this script


### PR DESCRIPTION
Styrene overrides the default path variable removing the `Windows\System32` entry which makes `findstr` unavailable when script is executed from the launcher `aeternity.exe` resulting in:

```
'findstr' is not recognized as an internal or external command,
operable program or batch file.
'findstr' is not recognized as an internal or external command,
operable program or batch file.
'findstr' is not recognized as an internal or external command,
operable program or batch file.
./usr/lib/aeternity/bin/aeternity.cmd exited with status 0.
Press return to close this window.
```
